### PR TITLE
DOT 1058 geofence history service nao deve contabilizar posicoes zeradas

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,7 +84,8 @@ func main() {
 					continue
 				}
 				if trackerMessage.LATITUDE == 0 && trackerMessage.LONGITUDE == 0 {
-					logger.Warning("Invalid tracker message")
+					logger.Warning("Invalid tracker message: Latitude and Longitude are 0")
+					continue
 				}
 
 				geofencePolygon := PolygonFromPrimitiveD.PolygonFromPrimitiveD(geojson)


### PR DESCRIPTION
- **filter invalid tracker messages**
- **added skip and better log message**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Correções de Bugs**
	- Mensagem de aviso aprimorada para mensagens de rastreamento inválidas com coordenadas de latitude e longitude iguais a zero, agora exibindo "Mensagem de rastreamento inválida: Latitude e Longitude são 0."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->